### PR TITLE
Encode Erlang datetime() and datetime() with microsecond (ec_date/Ecto style)

### DIFF
--- a/test/test1.yml
+++ b/test/test1.yml
@@ -1,5 +1,5 @@
 ---
-Time: 2001-11-23 15:01:42 -5
+Time: 2001-11-23 15:01:42 Z
 User: ed
 Warning:
   This is an error message


### PR DESCRIPTION
Adds encoding for `datetime()` (optionally with microseconds in the style of ec_date and
Elixir's Ecto) to YAML datetime specification.

Because Erlang has no native concept of timezones it is assumed datetime values are in
UTC time, and are encoded to YAML without an offset, implying UTC.